### PR TITLE
chore: indicate compatibility with nuxt v4

### DIFF
--- a/packages/nuxt-module/src/module.ts
+++ b/packages/nuxt-module/src/module.ts
@@ -12,7 +12,7 @@ export default defineNuxtModule<ModuleOptions>({
         name: '@primevue/nuxt-module',
         configKey: 'primevue',
         compatibility: {
-            nuxt: '^3.0.0'
+            nuxt: '>=3.0.0'
         }
     },
     defaults: {


### PR DESCRIPTION
This pull request includes a small but important change to the `packages/nuxt-module/src/module.ts` file. The change updates the Nuxt compatibility requirement to allow versions greater than or equal to `3.0.0`, instead of only versions starting with `3.0.0`.[u](https://github.com/primefaces/primevue/issues/7928)
